### PR TITLE
Use Python 3.10 for publication

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.10'
     - run: python -m pip install --upgrade tox-gh-actions
     - env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
The last run failed: https://github.com/dmtucker/metagit/runs/5812083216
```
tox: publish
  ERROR: InterpreterNotFound: python3.10
  ___________________________________ summary ____________________________________
  ERROR:  publish: InterpreterNotFound: python3.10
  Error: Process completed with exit code 1.
```